### PR TITLE
Don't log gulp-tenon to the console

### DIFF
--- a/gulp-tenon.js
+++ b/gulp-tenon.js
@@ -10,7 +10,7 @@ var clone = require('clone'),
 
 var PLUGIN_NAME = 'gulp-tenon';
 
-console.log(PLUGIN_NAME);
+// console.log(PLUGIN_NAME);
 
 module.exports = function(opts) {
   var options = merge({config: '.tenonrc'}, opts),


### PR DESCRIPTION
When using this plugin, when this file is imported, `gulp-tenon` is output to the console.

I'm not sure this is required, it's a little confusing it appears before any other gulp tasks are run - so I've commented it out.

