### PR TITLE
v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tenon-client",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Gulp Plugin for Tenon Accessibility Testing API",
   "main": "gulp-tenon.js",
   "dependencies": {


### PR DESCRIPTION
Bump version to 0.1.2 as it is a PATCH version.

Hi @egauci, would it be possible to merge this so we can use an updated version of your plugin which doesn't log `gulp-tenon` to the console when it is included? Many thanks!